### PR TITLE
thread safe connect, more nats callbacks and shutdown timeout 

### DIFF
--- a/lib/protobuf/nats.rb
+++ b/lib/protobuf/nats.rb
@@ -22,6 +22,8 @@ module Protobuf
       ACK = "\1".freeze
     end
 
+    GET_CONNECTED_MUTEX = ::Mutex.new
+
     def self.config
       @config ||= begin
         config = ::Protobuf::Nats::Config.new
@@ -50,7 +52,13 @@ module Protobuf
     end
 
     def self.ensure_client_nats_connection_was_started
-      @ensure_client_nats_connection_was_started ||= start_client_nats_connection
+      @ensure_client_nats_connection_was_started ||= begin
+        GET_CONNECTED_MUTEX.synchronize do
+          return if @ensure_client_nats_connection_was_started
+          start_client_nats_connection
+          true
+        end
+      end
     end
   end
 end

--- a/lib/protobuf/nats.rb
+++ b/lib/protobuf/nats.rb
@@ -42,23 +42,20 @@ module Protobuf
     end
 
     def self.start_client_nats_connection
-      @client_nats_connection = ::NATS::IO::Client.new
-      @client_nats_connection.connect(config.connection_options)
-
-      # Ensure we have a valid connection to the NATS server.
-      @client_nats_connection.flush(5)
-
-      true
-    end
-
-    def self.ensure_client_nats_connection_was_started
-      @ensure_client_nats_connection_was_started ||= begin
+      @start_client_nats_connection ||= begin
         GET_CONNECTED_MUTEX.synchronize do
-          return if @ensure_client_nats_connection_was_started
-          start_client_nats_connection
+          return if @start_client_nats_connection
+
+          @client_nats_connection = ::NATS::IO::Client.new
+          @client_nats_connection.connect(config.connection_options)
+
+          # Ensure we have a valid connection to the NATS server.
+          @client_nats_connection.flush(5)
+
           true
         end
       end
     end
+
   end
 end

--- a/lib/protobuf/nats/client.rb
+++ b/lib/protobuf/nats/client.rb
@@ -9,7 +9,8 @@ module Protobuf
         # may need to override to setup connection at this stage ... may also do on load of class
         super
 
-        ::Protobuf::Nats.ensure_client_nats_connection_was_started
+        # This will ensure the client is started.
+        ::Protobuf::Nats.start_client_nats_connection
       end
 
       def close_connection

--- a/lib/protobuf/nats/server.rb
+++ b/lib/protobuf/nats/server.rb
@@ -98,12 +98,14 @@ module Protobuf
           sleep 1
         end
 
+        logger.info "Unsubscribing from rpc routes..."
         subscriptions.each do |subscription_id|
           nats.unsubscribe(subscription_id)
         end
 
+        logger.info "Waiting up to 60 seconds for the thread pool to finish shutting down..."
         thread_pool.shutdown
-        thread_pool.wait_for_termination
+        thread_pool.wait_for_termination(60)
       ensure
         @stopped = true
       end

--- a/spec/protobuf/nats/server_spec.rb
+++ b/spec/protobuf/nats/server_spec.rb
@@ -31,6 +31,22 @@ describe ::Protobuf::Nats::Server do
     end
   end
 
+  describe "#log_error" do
+    it "does not log an error with a backtrace" do
+      expect(subject.logger).to receive(:error).with("yolo")
+      expect(subject.logger).to_not receive(:error).with("")
+      subject.log_error(::ArgumentError.new("yolo"))
+    end
+
+    it "logs errors with backtrace" do
+      error = ::ArgumentError.new("yolo")
+      allow(error).to receive(:backtrace).and_return(["line 1", "line 2"])
+      expect(subject.logger).to receive(:error).with("yolo")
+      expect(subject.logger).to_not receive(:error).with("line 1\nline2")
+      subject.log_error(error)
+    end
+  end
+
   describe "execute_request_promise" do
     it "returns nil when the thread pool and thread pool queue is full" do
       # Fill the thread pool.

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -14,6 +14,6 @@ RSpec.configure do |config|
   end
 
   config.before(:each) do
-    allow(Protobuf::Nats).to receive(:ensure_client_nats_connection_was_started)
+    allow(Protobuf::Nats).to receive(:start_client_nats_connection)
   end
 end


### PR DESCRIPTION
It's important we only create one connection because all is subs are tied to that client.

This also makes the shutdown timeout after 60 seconds to prevent servers from getting locked up when work doesn't complete in a timely manner.

This also adds some log lines because it's nice to know what's going on during shutdown.

cc @mmmries @quixoten @abrandoned 