### PR TITLE
Avoid double logging with `complete` callback

### DIFF
--- a/lib/protobuf/nats/client.rb
+++ b/lib/protobuf/nats/client.rb
@@ -28,10 +28,15 @@ module Protobuf
       rescue => error
         logger.debug { sign_message("Server failed request (invoking on_failure): #{error.inspect}") }
 
-        if @failure_cb
-          @failure_cb.call(error)
-        else
-          raise
+        begin
+          if @failure_cb
+            @failure_cb.call(error)
+          else
+            raise
+          end
+        ensure
+          # Complete stats and log
+          complete
         end
       end
 

--- a/lib/protobuf/nats/client.rb
+++ b/lib/protobuf/nats/client.rb
@@ -33,8 +33,6 @@ module Protobuf
         else
           raise
         end
-      ensure
-        complete
       end
 
       def send_request

--- a/spec/protobuf/nats/client_spec.rb
+++ b/spec/protobuf/nats/client_spec.rb
@@ -68,6 +68,7 @@ describe ::Protobuf::Nats::Client do
     it "retries 3 times and invokes error callback" do
       expect(subject).to receive(:setup_connection).exactly(3).times
       expect(subject).to receive(:nats_request_with_two_responses).and_raise(::NATS::IO::Timeout).exactly(3).times
+      expect(subject).to receive(:complete).exactly(1).times
 
       error = nil
       subject.failure_cb = lambda do |rpc_error|
@@ -81,6 +82,7 @@ describe ::Protobuf::Nats::Client do
     it "retries 3 times when and raises a NATS timeout when no error callback is provided" do
       expect(subject).to receive(:setup_connection).exactly(3).times
       expect(subject).to receive(:nats_request_with_two_responses).and_raise(::NATS::IO::Timeout).exactly(3).times
+      expect(subject).to receive(:complete).exactly(1).times
       expect { subject.send_request }.to raise_error(::NATS::IO::Timeout)
     end
   end


### PR DESCRIPTION
parse response will trigger this. we only need to call `complete` if we found an error.

cc @mmmries @quixoten @abrandoned 