### PR TITLE
zt/config service replacements

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,10 +38,12 @@ You can also use the following environment variables to tune parameters:
 ### YAML Config
 
 The client and server are configured via environment variables defined in the `pure-ruby-nats` gem. However, there are a
-few params which cannot be set: `servers`, `uses_tls` and `connect_timeout`, so those my be defined in a yml file.
+few params which cannot be set: `servers`, `uses_tls`, `service_replacements`, and `connect_timeout`, so those my be defined in a yml file.
 
 The library will automatically look for a file with a relative path of `config/protobuf_nats.yml`, but you may override
 this by specifying a different file via the `PROTOBUF_NATS_CONFIG_PATH` env variable.
+
+The `service_replacements` feature is something we have found useful for local testing, but it is subject to breaking changes.
 
 An example config looks like this:
 ```
@@ -58,6 +60,8 @@ An example config looks like this:
     tls_client_key: "/path/to/client-key.pem"
     tls_ca_cert: "/path/to/ca.pem"
     connect_timeout: 2
+    service_replacements:
+      - "original_service": "replacement_service
 ```
 
 ## Usage

--- a/README.md
+++ b/README.md
@@ -38,12 +38,12 @@ You can also use the following environment variables to tune parameters:
 ### YAML Config
 
 The client and server are configured via environment variables defined in the `pure-ruby-nats` gem. However, there are a
-few params which cannot be set: `servers`, `uses_tls`, `service_replacements`, and `connect_timeout`, so those my be defined in a yml file.
+few params which cannot be set: `servers`, `uses_tls`, `subscription_key_replacements`, and `connect_timeout`, so those my be defined in a yml file.
 
 The library will automatically look for a file with a relative path of `config/protobuf_nats.yml`, but you may override
 this by specifying a different file via the `PROTOBUF_NATS_CONFIG_PATH` env variable.
 
-The `service_replacements` feature is something we have found useful for local testing, but it is subject to breaking changes.
+The `subscription_key_replacements` feature is something we have found useful for local testing, but it is subject to breaking changes.
 
 An example config looks like this:
 ```
@@ -60,8 +60,8 @@ An example config looks like this:
     tls_client_key: "/path/to/client-key.pem"
     tls_ca_cert: "/path/to/ca.pem"
     connect_timeout: 2
-    service_replacements:
-      - "original_service": "replacement_service
+    subscription_key_replacements:
+      - "original_service": "replacement_service"
 ```
 
 ## Usage

--- a/lib/protobuf/nats.rb
+++ b/lib/protobuf/nats.rb
@@ -45,7 +45,9 @@ module Protobuf
     def self.subscription_key(service_klass, service_method)
       service_class_name = service_klass.name.underscore.gsub("/", ".")
       service_method_name = service_method.to_s.underscore
-      "rpc.#{service_class_name}.#{service_method_name}"
+
+      subscription_key = "rpc.#{service_class_name}.#{service_method_name}"
+      subscription_key = config.make_subscription_key_replacements(subscription_key)
     end
 
     def self.start_client_nats_connection

--- a/lib/protobuf/nats/config.rb
+++ b/lib/protobuf/nats/config.rb
@@ -4,7 +4,7 @@ require "yaml"
 module Protobuf
   module Nats
     class Config
-      attr_accessor :uses_tls, :servers, :connect_timeout, :tls_client_cert, :tls_client_key, :tls_ca_cert, :max_reconnect_attempts, :service_replacements
+      attr_accessor :uses_tls, :servers, :connect_timeout, :tls_client_cert, :tls_client_key, :tls_ca_cert, :max_reconnect_attempts, :subscription_key_replacements
 
       CONFIG_MUTEX = ::Mutex.new
 
@@ -16,7 +16,7 @@ module Protobuf
         :tls_client_key => nil,
         :tls_ca_cert => nil,
         :uses_tls => false,
-        :service_replacements => [],
+        :subscription_key_replacements => [],
       }.freeze
 
       def initialize
@@ -62,7 +62,7 @@ module Protobuf
             tls_client_key: tls_client_key,
             tls_ca_cert: tls_ca_cert,
             connect_timeout: connect_timeout,
-            service_replacements: service_replacements,
+            subscription_key_replacements: subscription_key_replacements,
           }
           options[:tls] = {:context => new_tls_context} if uses_tls
           options
@@ -78,7 +78,7 @@ module Protobuf
       end
 
       def make_subscription_key_replacements(subscription_key)
-        service_replacements.each do |replacement|
+        subscription_key_replacements.each do |replacement|
           match = replacement.keys.first
           replacement = replacement[match]
 

--- a/spec/protobuf/nats/config_spec.rb
+++ b/spec/protobuf/nats/config_spec.rb
@@ -16,7 +16,7 @@ describe ::Protobuf::Nats::Config do
       :tls_client_key => nil,
       :uses_tls => false,
       :max_reconnect_attempts => 60_000,
-      :service_replacements => [],
+      :subscription_key_replacements => [],
     }
     expect(subject.connection_options).to eq(expected_options)
   end
@@ -56,7 +56,7 @@ describe ::Protobuf::Nats::Config do
     expect(subject.uses_tls).to eq(true)
     expect(subject.connect_timeout).to eq(2)
     expect(subject.max_reconnect_attempts).to eq(1234)
-    expect(subject.service_replacements).to eq([{"original_" => "local_"}, {"another_subscription" => "different_subscription"}])
+    expect(subject.subscription_key_replacements).to eq([{"original_" => "local_"}, {"another_subscription" => "different_subscription"}])
 
     ENV["PROTOBUF_NATS_CONFIG_PATH"] = nil
   end
@@ -85,7 +85,7 @@ describe ::Protobuf::Nats::Config do
     ENV["PROTOBUF_NATS_CONFIG_PATH"] = nil
   end
 
-  it "replaces subscription_key using service_replacements" do
+  it "replaces subscription_key using subscription_key_replacements" do
     ENV["PROTOBUF_NATS_CONFIG_PATH"] = "spec/support/protobuf_nats.yml"
 
     subject.load_from_yml

--- a/spec/support/protobuf_nats.yml
+++ b/spec/support/protobuf_nats.yml
@@ -11,7 +11,7 @@
     tls_client_key: "./spec/support/certs/client-key.pem"
     tls_ca_cert: "./spec/support/certs/ca.pem"
     connect_timeout: 2
-    service_replacements:
+    subscription_key_replacements:
       - "original_": "local_"
       - "another_subscription": "different_subscription"
 

--- a/spec/support/protobuf_nats.yml
+++ b/spec/support/protobuf_nats.yml
@@ -11,6 +11,9 @@
     tls_client_key: "./spec/support/certs/client-key.pem"
     tls_ca_cert: "./spec/support/certs/ca.pem"
     connect_timeout: 2
+    service_replacements:
+      - "original_": "local_"
+      - "another_subscription": "different_subscription"
 
   development:
     <<: *defaults


### PR DESCRIPTION
Add configuration option to the protobuf_nats.yml file that will allow the replacement of a service.

```
  defaults: &defaults
    servers:
      - "some_server"
    service_replacements:
      - "normal_service.amigo: "local_service.amigo"
      - "normal_service.abacus": "local_service.abacus"
```

This allows the services to only point to local services based on the config, and then default to the normal service otherwise.

//RFC @film42 @abrandoned 