### PR TITLE
Add support for multiple error handlers (shared by client and server)

### DIFF
--- a/lib/protobuf/nats/server.rb
+++ b/lib/protobuf/nats/server.rb
@@ -44,7 +44,7 @@ module Protobuf
             # Publish response.
             nats.publish(reply_id, response_data)
           rescue => error
-            ::Protobuf::Nats.log_error(error)
+            ::Protobuf::Nats.notify_error_callbacks(error)
           end
         end
 
@@ -84,7 +84,7 @@ module Protobuf
         end
 
         nats.on_error do |error|
-          ::Protobuf::Nats.log_error(error)
+          ::Protobuf::Nats.notify_error_callbacks(error)
         end
 
         nats.on_close do

--- a/spec/protobuf/nats_spec.rb
+++ b/spec/protobuf/nats_spec.rb
@@ -11,6 +11,32 @@ describe ::Protobuf::Nats do
     expect(described_class.subscription_key(ExampleServiceKlassBro, :yolo_dude)).to eq("rpc.example_service_klass_bro.yolo_dude")
   end
 
+  describe "#on_error" do
+    # Reset error callbacks.
+    before { described_class.instance_variable_set(:@error_callbacks, nil) }
+    after { described_class.instance_variable_set(:@error_callbacks, nil) }
+
+    it "has a logger error handler" do
+      expect(described_class.error_callbacks.size).to eq(1)
+      expect(described_class).to receive(:log_error).with("test")
+      described_class.notify_error_callbacks("test")
+    end
+
+    it "can have multiple error callbacks" do
+      was_invoked = false
+      described_class.on_error do |_error|
+        was_invoked = true
+      end
+      expect(described_class.error_callbacks.size).to eq(2)
+      described_class.notify_error_callbacks(::ArgumentError.new("test"))
+      expect(was_invoked).to eq(true)
+    end
+
+    it "raises an argument error when a callback does not have arity of 1" do
+      expect { described_class.on_error {} }.to raise_error(::ArgumentError)
+    end
+  end
+
   describe "#log_error" do
     let(:logger) { ::Logger.new(nil) }
 
@@ -30,6 +56,17 @@ describe ::Protobuf::Nats do
       expect(logger).to receive(:error).with("yolo")
       expect(logger).to_not receive(:error).with("line 1\nline2")
       ::Protobuf::Nats.log_error(error)
+    end
+  end
+
+  describe "#notify_error_callbacks" do
+    it "logs an error raised by a callback" do
+      the_error = ::RuntimeError.new("Save me from my callback sadness!")
+      error_callback = lambda { |_error| fail the_error }
+      allow(described_class).to receive(:error_callbacks).and_return([error_callback])
+
+      expect(described_class).to receive(:log_error).with(the_error)
+      described_class.notify_error_callbacks("yolo")
     end
   end
 end


### PR DESCRIPTION
I think we might be able to just let the NATS client handle this, but
with two different clients, I think it's easier to handle this
ourselves.

cc @mmmries @abrandoned @quixoten 