### PR TITLE
Add server ip to ack response

### DIFF
--- a/lib/protobuf/nats.rb
+++ b/lib/protobuf/nats.rb
@@ -20,6 +20,7 @@ module Protobuf
 
     module Messages
       ACK = "\1".freeze
+      ACK_WITH_SERVER_PREFIX = "\2".freeze
     end
 
     NatsClient = if defined? JRUBY_VERSION

--- a/lib/protobuf/nats.rb
+++ b/lib/protobuf/nats.rb
@@ -19,8 +19,15 @@ module Protobuf
     end
 
     module Messages
-      ACK = "\1".freeze
-      ACK_WITH_SERVER_PREFIX = "\2".freeze
+      ACK = "\1".force_encoding(Encoding::BINARY).freeze
+
+      # \x80\x00 is used because it should never appear in a valid protobuf
+      # object, i.e.,
+      #
+      #     encode(decode("\x80\x00")) => "\x00"
+      #
+      # \x80\x00 through \xFF\x00 can all be used for this purpose.
+      ACK_WITH_SERVER = "\x80\x00".force_encoding(Encoding::BINARY).freeze
     end
 
     NatsClient = if defined? JRUBY_VERSION

--- a/lib/protobuf/nats/client.rb
+++ b/lib/protobuf/nats/client.rb
@@ -141,7 +141,6 @@ module Protobuf
           when ::Protobuf::Nats::Messages::ACK then has_ack = true
           when ::Protobuf::Nats::Messages::ACK_WITH_SERVER
             has_ack = true
-            @stats.server = second_message.data.byteslice(2..-1)
             @stats.server = [0, second_message.data.byteslice(2..-1)]
           else response = second_message.data
           end

--- a/lib/protobuf/nats/client.rb
+++ b/lib/protobuf/nats/client.rb
@@ -132,6 +132,9 @@ module Protobuf
           has_ack = false
           case first_message.data
           when ::Protobuf::Nats::Messages::ACK then has_ack = true
+          when /^#{::Protobuf::Nats::Messages::ACK_WITH_SERVER_PREFIX}/
+            has_ack = true
+            @stats.server = first_message.data[1..-1]
           else response = first_message.data
           end
           case second_message.data

--- a/lib/protobuf/nats/server.rb
+++ b/lib/protobuf/nats/server.rb
@@ -9,7 +9,7 @@ module Protobuf
       include ::Protobuf::Rpc::Server
       include ::Protobuf::Logging
 
-      attr_reader :nats, :thread_pool, :subscriptions, :server_ip, :ack_msg
+      attr_reader :nats, :thread_pool, :subscriptions, :server_name, :ack_msg
 
       def initialize(options)
         @options = options
@@ -23,9 +23,9 @@ module Protobuf
 
         @subscriptions = []
 
-        @server_ip = options.fetch(:server_ip, first_ipv4_address)
-        @ack_msg = if @server_ip
-                     "#{::Protobuf::Nats::Messages::ACK_WITH_SERVER_PREFIX}#{@server_ip}"
+        @server_name = options.fetch(:server_name, first_ipv4_address)
+        @ack_msg = if @server_name
+                     "#{::Protobuf::Nats::Messages::ACK_WITH_SERVER_PREFIX}#{@server_name}"
                    else
                      ::Protobuf::Nats::Messages::ACK
                    end

--- a/lib/protobuf/nats/server.rb
+++ b/lib/protobuf/nats/server.rb
@@ -9,7 +9,7 @@ module Protobuf
       include ::Protobuf::Rpc::Server
       include ::Protobuf::Logging
 
-      attr_reader :nats, :thread_pool, :subscriptions
+      attr_reader :nats, :thread_pool, :subscriptions, :server_ip, :ack_msg
 
       def initialize(options)
         @options = options
@@ -22,6 +22,13 @@ module Protobuf
         @thread_pool = ::Protobuf::Nats::ThreadPool.new(@options[:threads], :max_queue => max_queue_size)
 
         @subscriptions = []
+
+        @server_ip = options.fetch(:server_ip, first_ipv4_address)
+        @ack_msg = if @server_ip
+                     "#{::Protobuf::Nats::Messages::ACK_WITH_SERVER_PREFIX}#{@server_ip}"
+                   else
+                     ::Protobuf::Nats::Messages::ACK
+                   end
       end
 
       def max_queue_size
@@ -49,7 +56,7 @@ module Protobuf
         end
 
         # Publish an ACK to signal the server has picked up the work.
-        nats.publish(reply_id, ::Protobuf::Nats::Messages::ACK) if was_enqueued
+        nats.publish(reply_id, ack_msg) if was_enqueued
 
         was_enqueued
       end
@@ -118,6 +125,12 @@ module Protobuf
 
       def stop
         @running = false
+      end
+
+      def first_ipv4_address
+        Socket.ip_address_list.find { |addrinfo| addrinfo.ipv4? }.ip_address
+      rescue
+        nil
       end
     end
   end

--- a/lib/protobuf/nats/server.rb
+++ b/lib/protobuf/nats/server.rb
@@ -25,7 +25,7 @@ module Protobuf
 
         @server_name = options.fetch(:server_name, first_ipv4_address)
         @ack_msg = if @server_name
-                     "#{::Protobuf::Nats::Messages::ACK_WITH_SERVER_PREFIX}#{@server_name}"
+                     ::Protobuf::Nats::Messages::ACK_WITH_SERVER.dup << @server_name
                    else
                      ::Protobuf::Nats::Messages::ACK
                    end

--- a/spec/protobuf/nats/server_spec.rb
+++ b/spec/protobuf/nats/server_spec.rb
@@ -57,7 +57,7 @@ describe ::Protobuf::Nats::Server do
     it "sends an ACK if the thread pool enqueued the task" do
       # Fill the thread pool.
       2.times { subject.thread_pool.push { sleep 1 } }
-      expect(subject.nats).to receive(:publish).with("inbox_123", ::Protobuf::Nats::Messages::ACK)
+      expect(subject.nats).to receive(:publish).with("inbox_123", "#{::Protobuf::Nats::Messages::ACK_WITH_SERVER_PREFIX}127.0.0.1")
       # Wait for promise to finish executing.
       expect(subject.enqueue_request("", "inbox_123")).to eq(true)
       subject.thread_pool.kill
@@ -79,7 +79,7 @@ describe ::Protobuf::Nats::Server do
       response = "some response data"
       inbox = "inbox_123"
       expect(subject).to receive(:handle_request).and_return(response)
-      expect(client).to receive(:publish).once.ordered.with(inbox, ::Protobuf::Nats::Messages::ACK)
+      expect(client).to receive(:publish).once.ordered.with(inbox, "#{::Protobuf::Nats::Messages::ACK_WITH_SERVER_PREFIX}127.0.0.1")
       expect(client).to receive(:publish).once.ordered.with(inbox, response)
 
       # Wait for promise to finish executing.

--- a/spec/protobuf/nats/server_spec.rb
+++ b/spec/protobuf/nats/server_spec.rb
@@ -87,4 +87,23 @@ describe ::Protobuf::Nats::Server do
       sleep 0.1 until subject.thread_pool.size.zero?
     end
   end
+
+  describe "#server_name" do
+    it "is configurable via options" do
+      server = described_class.new(options.merge(:server_name => "blargh"))
+      expect(server.server_name).to eq("blargh")
+    end
+
+    it "is used in ack_msg when configured" do
+      server = described_class.new(options.merge(:server_name => "blargh"))
+      expect(server.ack_msg).to eq("\x80\x00blargh".force_encoding("BINARY"))
+    end
+
+    it "is the first available ipv4 address by default" do
+      expect(Socket).to receive(:ip_address_list).and_return([Addrinfo.ip("127.3.3.3")])
+      server = described_class.new(options)
+      expect(server.server_name).to eq("127.3.3.3")
+      expect(server.ack_msg).to eq("\x80\x00127.3.3.3".force_encoding("BINARY"))
+    end
+  end
 end

--- a/spec/protobuf/nats/server_spec.rb
+++ b/spec/protobuf/nats/server_spec.rb
@@ -57,7 +57,7 @@ describe ::Protobuf::Nats::Server do
     it "sends an ACK if the thread pool enqueued the task" do
       # Fill the thread pool.
       2.times { subject.thread_pool.push { sleep 1 } }
-      expect(subject.nats).to receive(:publish).with("inbox_123", "#{::Protobuf::Nats::Messages::ACK_WITH_SERVER_PREFIX}127.0.0.1")
+      expect(subject.nats).to receive(:publish).with("inbox_123", "#{subject.ack_msg}")
       # Wait for promise to finish executing.
       expect(subject.enqueue_request("", "inbox_123")).to eq(true)
       subject.thread_pool.kill
@@ -79,7 +79,7 @@ describe ::Protobuf::Nats::Server do
       response = "some response data"
       inbox = "inbox_123"
       expect(subject).to receive(:handle_request).and_return(response)
-      expect(client).to receive(:publish).once.ordered.with(inbox, "#{::Protobuf::Nats::Messages::ACK_WITH_SERVER_PREFIX}127.0.0.1")
+      expect(client).to receive(:publish).once.ordered.with(inbox, "#{subject.ack_msg}")
       expect(client).to receive(:publish).once.ordered.with(inbox, response)
 
       # Wait for promise to finish executing.


### PR DESCRIPTION
This will allow us to continue to tie a request to a specific server so
that kibana dashboards relying on it continue to work.

This may not work because I'm not sure we can guarantee a message starting with `\2` will only be the ack. What's a better way to do this? I could just send the IP back without any prefix and use a regex on that?

---

@abrandoned @film42 