### PR TITLE
Don't send non-pberrors into the client failure cb

### DIFF
--- a/spec/protobuf/nats/client_spec.rb
+++ b/spec/protobuf/nats/client_spec.rb
@@ -107,21 +107,7 @@ describe ::Protobuf::Nats::Client do
   end
 
   describe "#send_request" do
-    it "retries 3 times and invokes error callback" do
-      expect(subject).to receive(:setup_connection).exactly(3).times
-      expect(subject).to receive(:nats_request_with_two_responses).and_raise(::NATS::IO::Timeout).exactly(3).times
-      expect(subject).to receive(:complete).exactly(1).times
-
-      error = nil
-      subject.failure_cb = lambda do |rpc_error|
-        error = rpc_error
-      end
-      subject.send_request
-
-      expect(error.class).to eq(::NATS::IO::Timeout)
-    end
-
-    it "retries 3 times when and raises a NATS timeout when no error callback is provided" do
+    it "retries 3 times when and raises a NATS timeout" do
       expect(subject).to receive(:setup_connection).exactly(3).times
       expect(subject).to receive(:nats_request_with_two_responses).and_raise(::NATS::IO::Timeout).exactly(3).times
       expect(subject).to receive(:complete).exactly(1).times


### PR DESCRIPTION
Due to the code changes made here: https://github.com/liveh2o/active_remote/pull/58

cc @quixoten @mmmries @liveh2o