### PR TITLE
Slow Start

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,15 +25,21 @@ Or install it yourself as:
 
 You can also use the following environment variables to tune parameters:
 
-`PB_NATS_SERVER_MAX_QUEUE_SIZE` - The size of the queue in front of your thread pool (default: thread count passed to CLI)
+`PB_NATS_SERVER_MAX_QUEUE_SIZE` - The size of the queue in front of your thread pool (default: thread count passed to CLI).
 
-`PB_NATS_CLIENT_ACK_TIMEOUT` - Seconds to wait for an ACK from the rpc server (default: 5 seconds)
+`PB_NATS_SERVER_SLOW_START_DELAY` - Seconds to wait before adding another round of subscriptions (default 10).
 
-`PB_NATS_CLIENT_RESPONSE_TIMEOUT` - Seconds to wait for a non-ACK response from the rpc server (default: 60 seconds)
+`PB_NATS_SERVER_SUBSCRIPTIONS_PER_RPC_ROUTE` - Number of subscriptions to create for each rpc endpoint. This number is
+used to allow JVM based servers to warm-up slowly to prevent jolts in runtime performance across your RPC network
+(default: 10).
 
-`PB_NATS_CLIENT_RECONNECT_DELAY` - If we detect a reconnect delay, we will wait this many seconds (default: the ACK timeout)
+`PB_NATS_CLIENT_ACK_TIMEOUT` - Seconds to wait for an ACK from the rpc server (default: 5 seconds).
 
-`PROTOBUF_NATS_CONFIG_PATH` - Custom path to the config yaml (default: "config/protobuf_nats.yml")
+`PB_NATS_CLIENT_RESPONSE_TIMEOUT` - Seconds to wait for a non-ACK response from the rpc server (default: 60 seconds).
+
+`PB_NATS_CLIENT_RECONNECT_DELAY` - If we detect a reconnect delay, we will wait this many seconds (default: the ACK timeout).
+
+`PROTOBUF_NATS_CONFIG_PATH` - Custom path to the config yaml (default: "config/protobuf_nats.yml").
 
 ### YAML Config
 

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ You can also use the following environment variables to tune parameters:
 
 `PB_NATS_SERVER_SLOW_START_DELAY` - Seconds to wait before adding another round of subscriptions (default 10).
 
-`PB_NATS_SERVER_SUBSCRIPTIONS_PER_RPC_ROUTE` - Number of subscriptions to create for each rpc endpoint. This number is
+`PB_NATS_SERVER_SUBSCRIPTIONS_PER_RPC_ENDPOINT` - Number of subscriptions to create for each rpc endpoint. This number is
 used to allow JVM based servers to warm-up slowly to prevent jolts in runtime performance across your RPC network
 (default: 10).
 

--- a/lib/protobuf/nats/server.rb
+++ b/lib/protobuf/nats/server.rb
@@ -26,11 +26,7 @@ module Protobuf
       end
 
       def max_queue_size
-        if ::ENV.key?("PB_NATS_SERVER_MAX_QUEUE_SIZE")
-          ::ENV["PB_NATS_SERVER_MAX_QUEUE_SIZE"].to_i
-        else
-          @options[:threads]
-        end
+        ::ENV.fetch("PB_NATS_SERVER_MAX_QUEUE_SIZE", @options[:threads]).to_i
       end
 
       def service_klasses

--- a/lib/protobuf/nats/server.rb
+++ b/lib/protobuf/nats/server.rb
@@ -33,8 +33,8 @@ module Protobuf
         ::ENV.fetch("PB_NATS_SERVER_SLOW_START_DELAY", 10).to_i
       end
 
-      def subscriptions_per_rpc_route
-        ::ENV.fetch("PB_NATS_SERVER_SUBSCRIPTIONS_PER_RPC_ROUTE", 10).to_i
+      def subscriptions_per_rpc_endpoint
+        ::ENV.fetch("PB_NATS_SERVER_SUBSCRIPTIONS_PER_RPC_ENDPOINT", 10).to_i
       end
 
       def service_klasses
@@ -91,19 +91,19 @@ module Protobuf
       end
 
       # Slow start subscriptions by adding X rounds of subz every
-      # Y seconds, where X is subscriptions_per_rpc_route and Y is
+      # Y seconds, where X is subscriptions_per_rpc_endpoint and Y is
       # slow_start_delay.
       def finish_slow_start
         logger.info "Slow start has started..."
         completed = 1
 
         # We have (X - 1) here because we always subscribe at least once.
-        (subscriptions_per_rpc_route - 1).times do
+        (subscriptions_per_rpc_endpoint - 1).times do
           next unless @running
           completed += 1
           sleep slow_start_delay
           subscribe_to_services
-          logger.info "Slow start adding another round of subscriptions (#{completed}/#{subscriptions_per_rpc_route})..."
+          logger.info "Slow start adding another round of subscriptions (#{completed}/#{subscriptions_per_rpc_endpoint})..."
         end
 
         logger.info "Slow start finished."

--- a/lib/protobuf/nats/server.rb
+++ b/lib/protobuf/nats/server.rb
@@ -29,6 +29,14 @@ module Protobuf
         ::ENV.fetch("PB_NATS_SERVER_MAX_QUEUE_SIZE", @options[:threads]).to_i
       end
 
+      def slow_start_delay
+        ::ENV.fetch("PB_NATS_SERVER_SLOW_START_DELAY", 10).to_i
+      end
+
+      def subscriptions_per_rpc_route
+        ::ENV.fetch("PB_NATS_SERVER_SUBSCRIPTIONS_PER_RPC_ROUTE", 10).to_i
+      end
+
       def service_klasses
         ::Protobuf::Rpc::Service.implemented_services.map(&:safe_constantize)
       end
@@ -51,24 +59,54 @@ module Protobuf
         was_enqueued
       end
 
-      def subscribe_to_services
+      def print_subscription_keys
         logger.info "Creating subscriptions:"
+
+        with_each_subscription_key do |subscription_key|
+          logger.info "  - #{subscription_key}"
+        end
+      end
+
+      def subscribe_to_services
+        with_each_subscription_key do |subscription_key_and_queue|
+          subscriptions << nats.subscribe(subscription_key_and_queue, :queue => subscription_key_and_queue) do |request_data, reply_id, _subject|
+            unless enqueue_request(request_data, reply_id)
+              logger.error { "Thread pool is full! Dropping message for: #{subscription_key_and_queue}" }
+            end
+          end
+        end
+      end
+
+      def with_each_subscription_key
+        fail ::ArgumentError unless block_given?
 
         service_klasses.each do |service_klass|
           service_klass.rpcs.each do |service_method, _|
             # Skip services that are not implemented.
             next unless service_klass.method_defined? service_method
 
-            subscription_key_and_queue = ::Protobuf::Nats.subscription_key(service_klass, service_method)
-            logger.info "  - #{subscription_key_and_queue}"
-
-            subscriptions << nats.subscribe(subscription_key_and_queue, :queue => subscription_key_and_queue) do |request_data, reply_id, _subject|
-              unless enqueue_request(request_data, reply_id)
-                logger.error { "Thread pool is full! Dropping message for: #{subscription_key_and_queue}" }
-              end
-            end
+            yield ::Protobuf::Nats.subscription_key(service_klass, service_method)
           end
         end
+      end
+
+      # Slow start subscriptions by adding X rounds of subz every
+      # Y seconds, where X is subscriptions_per_rpc_route and Y is
+      # slow_start_delay.
+      def finish_slow_start
+        logger.info "Slow start has started..."
+        completed = 1
+
+        # We have (X - 1) here because we always subscribe at least once.
+        (subscriptions_per_rpc_route - 1).times do
+          next unless @running
+          completed += 1
+          sleep slow_start_delay
+          subscribe_to_services
+          logger.info "Slow start adding another round of subscriptions (#{completed}/#{subscriptions_per_rpc_route})..."
+        end
+
+        logger.info "Slow start finished."
       end
 
       def run
@@ -88,9 +126,10 @@ module Protobuf
           logger.warn "Server NATS connection was closed"
         end
 
+        print_subscription_keys
         subscribe_to_services
-
         yield if block_given?
+        finish_slow_start
 
         loop do
           break unless @running

--- a/lib/protobuf/nats/server.rb
+++ b/lib/protobuf/nats/server.rb
@@ -30,11 +30,11 @@ module Protobuf
       end
 
       def slow_start_delay
-        ::ENV.fetch("PB_NATS_SERVER_SLOW_START_DELAY", 10).to_i
+        @slow_start_delay ||= ::ENV.fetch("PB_NATS_SERVER_SLOW_START_DELAY", 10).to_i
       end
 
       def subscriptions_per_rpc_endpoint
-        ::ENV.fetch("PB_NATS_SERVER_SUBSCRIPTIONS_PER_RPC_ENDPOINT", 10).to_i
+        @subscriptions_per_rpc_endpoint ||= ::ENV.fetch("PB_NATS_SERVER_SUBSCRIPTIONS_PER_RPC_ENDPOINT", 10).to_i
       end
 
       def service_klasses

--- a/spec/protobuf/nats/server_spec.rb
+++ b/spec/protobuf/nats/server_spec.rb
@@ -39,6 +39,34 @@ describe ::Protobuf::Nats::Server do
     end
   end
 
+  describe "#slow_start_delay" do
+    it "has a default" do
+      expect(subject.slow_start_delay).to eq(10)
+    end
+
+    it "can be set via PB_NATS_SERVER_SLOW_START_DELAY environment variable" do
+      ::ENV["PB_NATS_SERVER_SLOW_START_DELAY"] = "20"
+
+      expect(subject.slow_start_delay).to eq(20)
+
+      ::ENV.delete("PB_NATS_SERVER_SLOW_START_DELAY")
+    end
+  end
+
+  describe "#subscriptions_per_rpc_route" do
+    it "has a default" do
+      expect(subject.subscriptions_per_rpc_route).to eq(10)
+    end
+
+    it "can be set via PB_NATS_SERVER_SUBSCRIPTIONS_PER_RPC_ROUTE environment variable" do
+      ::ENV["PB_NATS_SERVER_SUBSCRIPTIONS_PER_RPC_ROUTE"] = "20"
+
+      expect(subject.subscriptions_per_rpc_route).to eq(20)
+
+      ::ENV.delete("PB_NATS_SERVER_SUBSCRIPTIONS_PER_RPC_ROUTE")
+    end
+  end
+
   describe "#subscribe_to_services" do
     it "subscribes to services that inherit from protobuf rpc service" do
       subject.subscribe_to_services

--- a/spec/protobuf/nats/server_spec.rb
+++ b/spec/protobuf/nats/server_spec.rb
@@ -53,17 +53,17 @@ describe ::Protobuf::Nats::Server do
     end
   end
 
-  describe "#subscriptions_per_rpc_route" do
+  describe "#subscriptions_per_rpc_endpoint" do
     it "has a default" do
-      expect(subject.subscriptions_per_rpc_route).to eq(10)
+      expect(subject.subscriptions_per_rpc_endpoint).to eq(10)
     end
 
-    it "can be set via PB_NATS_SERVER_SUBSCRIPTIONS_PER_RPC_ROUTE environment variable" do
-      ::ENV["PB_NATS_SERVER_SUBSCRIPTIONS_PER_RPC_ROUTE"] = "20"
+    it "can be set via PB_NATS_SERVER_SUBSCRIPTIONS_PER_RPC_ENDPOINT environment variable" do
+      ::ENV["PB_NATS_SERVER_SUBSCRIPTIONS_PER_RPC_ENDPOINT"] = "20"
 
-      expect(subject.subscriptions_per_rpc_route).to eq(20)
+      expect(subject.subscriptions_per_rpc_endpoint).to eq(20)
 
-      ::ENV.delete("PB_NATS_SERVER_SUBSCRIPTIONS_PER_RPC_ROUTE")
+      ::ENV.delete("PB_NATS_SERVER_SUBSCRIPTIONS_PER_RPC_ENDPOINT")
     end
   end
 


### PR DESCRIPTION
Since NATS is always evenly routing traffic, we'd like to be able to warm up servers. One way we can do this is by increasing the number of subscriptions per endpoint and slowly increase that number as servers are started. This will give each server a smaller portion of traffic. The default right now is add a new round of subz every 10 seconds to have a total of 10 subz per endpoint. These are tunable with new env vars:

`PB_NATS_SERVER_SLOW_START_DELAY` - delay in seconds between adding each new round of subz.

`PB_NATS_SERVER_SUBSCRIPTIONS_PER_RPC_ENDPOINT` - total number of subz per endpoint. always does at least one and then (this number - 1) are added in the slow start phase.

cc @mmmries @quixoten @abrandoned 
