### PR TITLE
Add ability for server to be paused and resumed

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,9 @@ You can also use the following environment variables to tune parameters:
 
 `PB_NATS_SERVER_MAX_QUEUE_SIZE` - The size of the queue in front of your thread pool (default: thread count passed to CLI).
 
+`PB_NATS_SERVER_PAUSE_FILE_PATH` - If this file exists, the server will pause by unsubscribing all services. When the
+file is resumed it will resubscribe and restart slow start (default: `nil`).
+
 `PB_NATS_SERVER_SLOW_START_DELAY` - Seconds to wait before adding another round of subscriptions (default 10).
 
 `PB_NATS_SERVER_SUBSCRIPTIONS_PER_RPC_ENDPOINT` - Number of subscriptions to create for each rpc endpoint. This number is

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ You can also use the following environment variables to tune parameters:
 `PB_NATS_SERVER_MAX_QUEUE_SIZE` - The size of the queue in front of your thread pool (default: thread count passed to CLI).
 
 `PB_NATS_SERVER_PAUSE_FILE_PATH` - If this file exists, the server will pause by unsubscribing all services. When the
-file is resumed it will resubscribe and restart slow start (default: `nil`).
+file is removed it will resubscribe and restart slow start (default: `nil`).
 
 `PB_NATS_SERVER_SLOW_START_DELAY` - Seconds to wait before adding another round of subscriptions (default 10).
 

--- a/lib/protobuf/nats/server.rb
+++ b/lib/protobuf/nats/server.rb
@@ -13,6 +13,7 @@ module Protobuf
 
       def initialize(options)
         @options = options
+        @processing_requests = true
         @running = true
         @stopped = false
 
@@ -59,6 +60,10 @@ module Protobuf
         was_enqueued
       end
 
+      def pause_file_path
+        ::ENV.fetch("PB_NATS_SERVER_PAUSE_FILE_PATH", nil)
+      end
+
       def print_subscription_keys
         logger.info "Creating subscriptions:"
 
@@ -67,7 +72,7 @@ module Protobuf
         end
       end
 
-      def subscribe_to_services
+      def subscribe_to_services_once
         with_each_subscription_key do |subscription_key_and_queue|
           subscriptions << nats.subscribe(subscription_key_and_queue, :queue => subscription_key_and_queue) do |request_data, reply_id, _subject|
             unless enqueue_request(request_data, reply_id)
@@ -100,13 +105,34 @@ module Protobuf
         # We have (X - 1) here because we always subscribe at least once.
         (subscriptions_per_rpc_endpoint - 1).times do
           next unless @running
+          next if paused?
           completed += 1
           sleep slow_start_delay
-          subscribe_to_services
+          subscribe_to_services_once
           logger.info "Slow start adding another round of subscriptions (#{completed}/#{subscriptions_per_rpc_endpoint})..."
         end
 
         logger.info "Slow start finished."
+      end
+
+      def detect_and_handle_a_pause
+        case
+        # If we are taking requests and detect a pause file, then unsubscribe.
+        when @processing_requests && paused?
+          @processing_requests = false
+          logger.warn("Pausing server!")
+          unsubscribe
+
+        # If we were paused and the pause file is no longer present, then subscribe again.
+        when !@processing_requests && !paused?
+          logger.warn("Resuming server: resubscribing to all services and restarting slow start!")
+          @processing_requests = true
+          subscribe
+        end
+      end
+
+      def paused?
+        !pause_file_path.nil? && ::File.exist?(pause_file_path)
       end
 
       def run
@@ -127,19 +153,15 @@ module Protobuf
         end
 
         print_subscription_keys
-        subscribe_to_services
-        yield if block_given?
-        finish_slow_start
+        subscribe { yield if block_given? }
 
         loop do
           break unless @running
+          detect_and_handle_a_pause
           sleep 1
         end
 
-        logger.info "Unsubscribing from rpc routes..."
-        subscriptions.each do |subscription_id|
-          nats.unsubscribe(subscription_id)
-        end
+        unsubscribe
 
         logger.info "Waiting up to 60 seconds for the thread pool to finish shutting down..."
         thread_pool.shutdown
@@ -154,6 +176,19 @@ module Protobuf
 
       def stop
         @running = false
+      end
+
+      def subscribe
+        subscribe_to_services_once
+        yield if block_given?
+        finish_slow_start
+      end
+
+      def unsubscribe
+        logger.info "Unsubscribing from rpc routes..."
+        subscriptions.each do |subscription_id|
+          nats.unsubscribe(subscription_id)
+        end
       end
     end
   end

--- a/lib/protobuf/nats/server.rb
+++ b/lib/protobuf/nats/server.rb
@@ -153,7 +153,11 @@ module Protobuf
         end
 
         print_subscription_keys
-        subscribe { yield if block_given? }
+        if paused?
+          yield if block_given?
+        else
+          subscribe { yield if block_given? }
+        end
 
         loop do
           break unless @running


### PR DESCRIPTION
This feature from the zmq rpc server is missed by some, and this PR is a way of mimicking that behavior.

I don't think we need this behavior, but some people really want it.

This adds a `PB_NATS_SERVER_PAUSE_FILE_PATH` env variable that you can set and the server will check for that file every second. ~~The server will startup like normal by subscribing and then check for this file. So there's still a second where it might try to process a request when restarted.~~

A file was easier to deal with than listening for a `HUP` signal, and it's easy to opt in or out of this way.

What do you think?

cc @abrandoned @mmmries @quixoten 