### PR TITLE
Add client support for nack

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,8 +40,8 @@ used to allow JVM based servers to warm-up slowly to prevent jolts in runtime pe
 
 `PB_NATS_CLIENT_NACK_BACKOFF_INTERVALS` - Array of milliseconds to wait between NACK retries (default: "0,1,3,5,10").
 
-`PB_NATS_CLIENT_NACK_BACKOFF_SPLAY_LIMIT` - Milliseconds to add to backoff timeout to avoid bursting retries (default:
-10 milliseconds).
+`PB_NATS_CLIENT_NACK_BACKOFF_SPLAY_LIMIT` - Milliseconds to add to the NACK backoff timeout to avoid bursting retries
+(default: 10 milliseconds).
 
 `PB_NATS_CLIENT_RESPONSE_TIMEOUT` - Seconds to wait for a non-ACK response from the rpc server (default: 60 seconds).
 

--- a/README.md
+++ b/README.md
@@ -38,6 +38,11 @@ used to allow JVM based servers to warm-up slowly to prevent jolts in runtime pe
 
 `PB_NATS_CLIENT_ACK_TIMEOUT` - Seconds to wait for an ACK from the rpc server (default: 5 seconds).
 
+`PB_NATS_CLIENT_NACK_BACKOFF_INTERVALS` - Array of milliseconds to wait between NACK retries (default: "0,1,3,5,10").
+
+`PB_NATS_CLIENT_NACK_BACKOFF_SPLAY_LIMIT` - Milliseconds to add to backoff timeout to avoid bursting retries (default:
+10 milliseconds).
+
 `PB_NATS_CLIENT_RESPONSE_TIMEOUT` - Seconds to wait for a non-ACK response from the rpc server (default: 60 seconds).
 
 `PB_NATS_CLIENT_RECONNECT_DELAY` - If we detect a reconnect delay, we will wait this many seconds (default: the ACK timeout).

--- a/lib/protobuf/nats.rb
+++ b/lib/protobuf/nats.rb
@@ -19,7 +19,8 @@ module Protobuf
     end
 
     module Messages
-      ACK = "\1".freeze
+      ACK  = "\1".freeze
+      NACK = "\2".freeze
     end
 
     NatsClient = if defined? JRUBY_VERSION

--- a/lib/protobuf/nats/client.rb
+++ b/lib/protobuf/nats/client.rb
@@ -113,7 +113,7 @@ module Protobuf
           # Wait for reply
           first_message = nats.next_message(sub, ack_timeout)
           fail ::NATS::IO::Timeout if first_message.nil?
-          fail NackError if first_message == ::Protobuf::Nats::Messages::NACK
+          fail NackError if first_message.data == ::Protobuf::Nats::Messages::NACK
           second_message = nats.next_message(sub, timeout)
           fail ::NATS::IO::Timeout if second_message.nil?
 

--- a/lib/protobuf/nats/server.rb
+++ b/lib/protobuf/nats/server.rb
@@ -55,7 +55,12 @@ module Protobuf
         end
 
         # Publish an ACK to signal the server has picked up the work.
-        nats.publish(reply_id, ::Protobuf::Nats::Messages::ACK) if was_enqueued
+        if was_enqueued
+          nats.publish(reply_id, ::Protobuf::Nats::Messages::ACK)
+        else
+          # pending client support being rolled out
+          # nats.publish(reply_id, ::Protobuf::Nats::Messages::NACK)
+        end
 
         was_enqueued
       end

--- a/spec/fake_nats_client.rb
+++ b/spec/fake_nats_client.rb
@@ -57,3 +57,13 @@ class FakeNatsClient
     end
   end
 end
+
+class FakeNackClient < FakeNatsClient
+  def subscribe(subject, args, &block)
+    Thread.new { block.call(::Protobuf::Nats::Messages::NACK) }
+  end
+
+  def next_message(_sub, _timeout)
+    FakeNatsClient::Message.new("", ::Protobuf::Nats::Messages::NACK, 0)
+  end
+end

--- a/spec/protobuf/nats/client_spec.rb
+++ b/spec/protobuf/nats/client_spec.rb
@@ -108,6 +108,8 @@ describe ::Protobuf::Nats::Client do
 
     it "raises an error when the server responds with nack" do
       client.schedule_messages([::FakeNatsClient::Message.new(inbox, nack, 0.05)])
+
+      options = {:timeout => 0.1}
       expect { subject.nats_request_with_two_responses(msg_subject, "request data", options) }.to raise_error(::Protobuf::Nats::Client::NackError)
     end
   end

--- a/spec/protobuf/nats/client_spec.rb
+++ b/spec/protobuf/nats/client_spec.rb
@@ -69,6 +69,7 @@ describe ::Protobuf::Nats::Client do
     let(:inbox) { "INBOX_123" }
     let(:msg_subject) { "rpc.yolo.brolo" }
     let(:ack) { ::Protobuf::Nats::Messages::ACK }
+    let(:nack) { ::Protobuf::Nats::Messages::NACK }
     let(:response) { "final count down" }
 
     before do
@@ -103,6 +104,13 @@ describe ::Protobuf::Nats::Client do
 
       options = {:timeout => 0.1}
       expect { subject.nats_request_with_two_responses(msg_subject, "request data", options) }.to raise_error(::NATS::IO::Timeout)
+    end
+
+    it "raises an error when the server responds with nack" do
+      client.schedule_messages([::FakeNatsClient::Message.new(inbox, nack, 0.05)])
+
+      options = {:timeout => 0.1}
+      expect { subject.nats_request_with_two_responses(msg_subject, "request data", options) }.to raise_error(Protobuf::Nats::Client::NackError)
     end
   end
 

--- a/spec/protobuf/nats/client_spec.rb
+++ b/spec/protobuf/nats/client_spec.rb
@@ -108,8 +108,6 @@ describe ::Protobuf::Nats::Client do
 
     it "raises an error when the server responds with nack" do
       client.schedule_messages([::FakeNatsClient::Message.new(inbox, nack, 0.05)])
-
-      options = {:timeout => 0.1}
       expect { subject.nats_request_with_two_responses(msg_subject, "request data", options) }.to raise_error(::Protobuf::Nats::Client::NackError)
     end
   end


### PR DESCRIPTION
I was initially against adding a nack, but I think there are some benefits to it. Using a nack allows the client to backoff more intelligently and with smaller intervals. This PR adds support to the client, but does not add support to the server. Once all clients have been upgraded to this version, support for the server side can be added.

I'm wondering if it might make sense to remove ACK completely and just rely on NACKs and a single timeout. Doing so would remove remove the possibility for a request to be duplicated at the rpc layer. It would also remove the need to receive two responses for every request. On the other hand, it would no longer cover the case that all servers stop responding (if they're all OOM killed in close proximity for example). The ACK allows us to fail in 15 seconds rather than 60 seconds in that scenario.

---

RFC @abrandoned @film42