### PR TITLE
Split NATS timeout into a request and response timeout

### DIFF
--- a/lib/protobuf/nats/errors.rb
+++ b/lib/protobuf/nats/errors.rb
@@ -1,6 +1,15 @@
 module Protobuf
   module Nats
     module Errors
+      class Base < ::StandardError
+      end
+
+      class RequestTimeout < Base
+      end
+
+      class ResponseTimeout < Base
+      end
+
       class MriIOException < ::StandardError
       end
 


### PR DESCRIPTION
We will raise a request timeout if no ack or nack is received. In other
words, if we have received any message but no protocol message, then we
consider the request a request timeout because the server could not
inform the client that it should expect a response. When the server
signals to the client that a response is incoming, but no message is
received, we will raise a response timeout.

cc @abrandoned @quixoten @liveh2o @mmmries 