### PR TITLE
Fix race condition around client connection setup

### DIFF
--- a/lib/protobuf/nats/client.rb
+++ b/lib/protobuf/nats/client.rb
@@ -5,14 +5,6 @@ require "monitor"
 module Protobuf
   module Nats
     class Client < ::Protobuf::Rpc::Connectors::Base
-      def initialize(options)
-        # may need to override to setup connection at this stage ... may also do on load of class
-        super
-
-        # This will ensure the client is started.
-        ::Protobuf::Nats.start_client_nats_connection
-      end
-
       def close_connection
         # no-op (I think for now), the connection to server is persistent
       end
@@ -102,6 +94,12 @@ module Protobuf
 
         retry if (retries -= 1) > 0
         raise
+      end
+
+      def setup_connection
+        # This will ensure the client is started.
+        ::Protobuf::Nats.start_client_nats_connection
+        super
       end
 
       def cached_subscription_key

--- a/lib/protobuf/nats/client.rb
+++ b/lib/protobuf/nats/client.rb
@@ -104,7 +104,7 @@ module Protobuf
         # Avoid client connect race condition where two threads attempt to connect
         # and one is kicked out of the memoized method before the connection has been
         # established. This rarely happens, but can happen.
-        until ::Protobuf::Nats.client_nats_connection.connected?
+        until ::Protobuf::Nats.client_nats_connection && ::Protobuf::Nats.client_nats_connection.connected?
           logger.warn "Client NATS connection was started but has not connected. Waiting 10ms..."
           sleep 0.01
         end

--- a/lib/protobuf/nats/jnats.rb
+++ b/lib/protobuf/nats/jnats.rb
@@ -68,6 +68,10 @@ module Protobuf
         @connection
       end
 
+      def connected?
+        !@connection.nil?
+      end
+
       # Do not depend on #close for a greaceful disconnect.
       def close
         @connection.close

--- a/spec/fake_nats_client.rb
+++ b/spec/fake_nats_client.rb
@@ -14,6 +14,10 @@ class FakeNatsClient
   def connect(*)
   end
 
+  def connected?
+    true
+  end
+
   def new_inbox
     @inbox
   end

--- a/spec/protobuf/nats/client_spec.rb
+++ b/spec/protobuf/nats/client_spec.rb
@@ -189,7 +189,7 @@ describe ::Protobuf::Nats::Client do
     it "starts a NATS connection" do
       client = ::FakeNackClient.new
       expect(::Protobuf::Nats).to receive(:start_client_nats_connection)
-      expect(::Protobuf::Nats).to receive(:client_nats_connection).and_return(client)
+      allow(::Protobuf::Nats).to receive(:client_nats_connection).and_return(client)
       expect(subject).to receive(:request_bytes).and_return("")
       expect(subject).to receive(:parse_response).and_return("")
       expect(subject).to receive(:nats_request_with_two_responses)
@@ -201,11 +201,11 @@ describe ::Protobuf::Nats::Client do
       expect(client).to receive(:connected?).and_return(false, false, true)
 
       expect(::Protobuf::Nats).to receive(:start_client_nats_connection)
+      allow(::Protobuf::Nats).to receive(:client_nats_connection).and_return(client)
+
       expect(subject).to receive(:request_bytes).and_return("")
       expect(subject).to receive(:parse_response).and_return("")
       expect(subject).to receive(:nats_request_with_two_responses)
-
-      expect(::Protobuf::Nats).to receive(:client_nats_connection).and_return(client).exactly(3).times
       expect(subject.logger).to receive(:warn).with("Client NATS connection was started but has not connected. Waiting 10ms...").exactly(2).times
       subject.send_request
     end

--- a/spec/protobuf/nats/client_spec.rb
+++ b/spec/protobuf/nats/client_spec.rb
@@ -184,4 +184,31 @@ describe ::Protobuf::Nats::Client do
       expect { subject.send_request }.to raise_error(error)
     end
   end
+
+  describe "#setup_connection" do
+    it "starts a NATS connection" do
+      client = ::FakeNackClient.new
+      expect(::Protobuf::Nats).to receive(:start_client_nats_connection)
+      expect(::Protobuf::Nats).to receive(:client_nats_connection).and_return(client)
+      expect(subject).to receive(:request_bytes).and_return("")
+      expect(subject).to receive(:parse_response).and_return("")
+      expect(subject).to receive(:nats_request_with_two_responses)
+      subject.send_request
+    end
+
+    it "waits for a client nats connection to be established by waiting 10ms" do
+      client = ::FakeNackClient.new
+      expect(client).to receive(:connected?).and_return(false, false, true)
+
+      expect(::Protobuf::Nats).to receive(:start_client_nats_connection)
+      expect(subject).to receive(:request_bytes).and_return("")
+      expect(subject).to receive(:parse_response).and_return("")
+      expect(subject).to receive(:nats_request_with_two_responses)
+
+      expect(::Protobuf::Nats).to receive(:client_nats_connection).and_return(client).exactly(3).times
+      expect(subject.logger).to receive(:warn).with("Client NATS connection was started but has not connected. Waiting 10ms...").exactly(2).times
+      subject.send_request
+    end
+
+  end
 end


### PR DESCRIPTION
There's a race condition around starting a client nats condition. It's possible two threads call `Protobuf::Nats.start_client_nats_connection` and one of them beats the other into the synchronize block and the other hits a memoized instance variable and returns early. The first thread waits for the connection to establish, but the second one does not. To fix this, I added a 10ms delay to the client if the NATS connection instance is not created or established.

One thing that isn't great is a subtle change in behavior between ruby and java. Ruby checks the connection state, where java is only checking the existence of a connection. From the start both of these are established, but they're not quite the same thing. Should an error occur, both clients will retry.

cc @abrandoned @quixoten @mmmries `