### PR TITLE
use a pool of subscriptions when a subscription pool is configured (f…

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+.ruby-*
 /.bundle/
 /.yardoc
 /Gemfile.lock

--- a/README.md
+++ b/README.md
@@ -47,6 +47,8 @@ used to allow JVM based servers to warm-up slowly to prevent jolts in runtime pe
 
 `PB_NATS_CLIENT_RECONNECT_DELAY` - If we detect a reconnect delay, we will wait this many seconds (default: the ACK timeout).
 
+`PB_NATS_CLIENT_SUBSCRIPTION_POOL_SIZE` - If subscription pooling is desired for the request/response cycle then the pool size maximum should be set; the pool is lazy and therefore will only start new subscriptions as necessary (default: 0)
+
 `PROTOBUF_NATS_CONFIG_PATH` - Custom path to the config yaml (default: "config/protobuf_nats.yml").
 
 ### YAML Config

--- a/README.md
+++ b/README.md
@@ -76,6 +76,12 @@ An example config looks like this:
     tls_client_key: "/path/to/client-key.pem"
     tls_ca_cert: "/path/to/ca.pem"
     connect_timeout: 2
+    server_subscription_key_only_subscribe_to_when_includes_any_of:
+      - "search"
+      - "create"
+    server_subscription_key_do_not_subscribe_to_when_includes_any_of:
+      - "old_search"
+      - "old_create"
     subscription_key_replacements:
       - "original_service": "replacement_service"
 ```

--- a/lib/protobuf/nats/client.rb
+++ b/lib/protobuf/nats/client.rb
@@ -58,7 +58,7 @@ module Protobuf
             return_value = yield sub_inbox
           end
         else
-         return_value = yield new_subscription_inbox
+          return_value = yield new_subscription_inbox
         end
 
         return_value

--- a/lib/protobuf/nats/client.rb
+++ b/lib/protobuf/nats/client.rb
@@ -128,7 +128,7 @@ module Protobuf
       def send_request
         if use_subscription_pooling?
           available = self.class.subscription_pool.instance_variable_get("@available")
-          ::ActiveSupport::Notifications.instrument "client.pool_availble_size.protobuf-nats", available.length
+          ::ActiveSupport::Notifications.instrument "client.pool_available_size.protobuf-nats", available.length
         end
 
         ::ActiveSupport::Notifications.instrument "client.request_duration.protobuf-nats" do

--- a/lib/protobuf/nats/client.rb
+++ b/lib/protobuf/nats/client.rb
@@ -126,6 +126,9 @@ module Protobuf
       end
 
       def send_request
+        # This will ensure the client is started.
+        ::Protobuf::Nats.start_client_nats_connection
+
         if use_subscription_pooling?
           available = self.class.subscription_pool.instance_variable_get("@available")
           ::ActiveSupport::Notifications.instrument "client.subscription_pool_available_size.protobuf-nats", available.length

--- a/lib/protobuf/nats/client.rb
+++ b/lib/protobuf/nats/client.rb
@@ -203,7 +203,7 @@ module Protobuf
 
             if first_message.nil?
               nats.unsubscribe(sub_inbox.subscription)
-              sub_inbox = new_subscription_inbox
+              sub_inbox = new_subscription_inbox # this line replaces the sub_inbox in the connection pool if necessary
               return :ack_timeout
             end
 

--- a/lib/protobuf/nats/config.rb
+++ b/lib/protobuf/nats/config.rb
@@ -4,7 +4,10 @@ require "yaml"
 module Protobuf
   module Nats
     class Config
-      attr_accessor :uses_tls, :servers, :connect_timeout, :tls_client_cert, :tls_client_key, :tls_ca_cert, :max_reconnect_attempts, :subscription_key_replacements
+      attr_accessor :uses_tls, :servers, :connect_timeout, :tls_client_cert, :tls_client_key, :tls_ca_cert, :max_reconnect_attempts
+      attr_accessor :server_subscription_key_do_not_subscribe_to_when_includes_any_of,
+                    :server_subscription_key_only_subscribe_to_when_includes_any_of,
+                    :subscription_key_replacements
 
       CONFIG_MUTEX = ::Mutex.new
 
@@ -16,6 +19,8 @@ module Protobuf
         :tls_client_key => nil,
         :tls_ca_cert => nil,
         :uses_tls => false,
+        :server_subscription_key_do_not_subscribe_to_when_includes_any_of => [],
+        :server_subscription_key_only_subscribe_to_when_includes_any_of => [],
         :subscription_key_replacements => [],
       }.freeze
 
@@ -62,6 +67,8 @@ module Protobuf
             tls_client_key: tls_client_key,
             tls_ca_cert: tls_ca_cert,
             connect_timeout: connect_timeout,
+            server_subscription_key_do_not_subscribe_to_when_includes_any_of: server_subscription_key_do_not_subscribe_to_when_includes_any_of,
+            server_subscription_key_only_subscribe_to_when_includes_any_of: server_subscription_key_only_subscribe_to_when_includes_any_of,
             subscription_key_replacements: subscription_key_replacements,
           }
           options[:tls] = {:context => new_tls_context} if uses_tls

--- a/lib/protobuf/nats/server.rb
+++ b/lib/protobuf/nats/server.rb
@@ -80,6 +80,24 @@ module Protobuf
         was_enqueued
       end
 
+      def do_not_subscribe_to_includes?(subscription_key)
+        return false unless ::Protobuf::Nats.config.server_subscription_key_do_not_subscribe_to_when_includes_any_of.respond_to?(:any?)
+        return false if ::Protobuf::Nats.config.server_subscription_key_do_not_subscribe_to_when_includes_any_of.empty?
+
+        ::Protobuf::Nats.config.server_subscription_key_do_not_subscribe_to_when_includes_any_of.any? do |key|
+          subscription_key.include?(key)
+        end
+      end
+
+      def only_subscribe_to_includes?(subscription_key)
+        return true unless ::Protobuf::Nats.config.server_subscription_key_only_subscribe_to_when_includes_any_of.respond_to?(:any?)
+        return true if ::Protobuf::Nats.config.server_subscription_key_only_subscribe_to_when_includes_any_of.empty?
+
+        ::Protobuf::Nats.config.server_subscription_key_only_subscribe_to_when_includes_any_of.any? do |key|
+          subscription_key.include?(key)
+        end
+      end
+
       def pause_file_path
         ::ENV.fetch("PB_NATS_SERVER_PAUSE_FILE_PATH", nil)
       end
@@ -108,9 +126,12 @@ module Protobuf
         service_klasses.each do |service_klass|
           service_klass.rpcs.each do |service_method, _|
             # Skip services that are not implemented.
-            next unless service_klass.method_defined? service_method
+            next unless service_klass.method_defined?(service_method)
+            subscription_key = ::Protobuf::Nats.subscription_key(service_klass, service_method)
+            next if do_not_subscribe_to_includes?(subscription_key)
+            next unless only_subscribe_to_includes?(subscription_key)
 
-            yield ::Protobuf::Nats.subscription_key(service_klass, service_method)
+            yield subscription_key
           end
         end
       end

--- a/lib/protobuf/nats/version.rb
+++ b/lib/protobuf/nats/version.rb
@@ -1,5 +1,5 @@
 module Protobuf
   module Nats
-    VERSION = "0.9.0.pre2"
+    VERSION = "0.9.0.pre3"
   end
 end

--- a/lib/protobuf/nats/version.rb
+++ b/lib/protobuf/nats/version.rb
@@ -1,5 +1,5 @@
 module Protobuf
   module Nats
-    VERSION = "0.8.0"
+    VERSION = "0.9.0.pre1"
   end
 end

--- a/lib/protobuf/nats/version.rb
+++ b/lib/protobuf/nats/version.rb
@@ -1,5 +1,5 @@
 module Protobuf
   module Nats
-    VERSION = "0.9.0.pre1"
+    VERSION = "0.9.0.pre2"
   end
 end

--- a/protobuf-nats.gemspec
+++ b/protobuf-nats.gemspec
@@ -31,6 +31,7 @@ Gem::Specification.new do |spec|
   spec.require_paths = ["lib"]
 
   spec.add_runtime_dependency "activesupport", ">= 3.2"
+  spec.add_runtime_dependency "connection_pool"
   spec.add_runtime_dependency "protobuf", "~> 3.7", ">= 3.7.2"
   spec.add_runtime_dependency "nats-pure"
 

--- a/spec/protobuf/nats/client_spec.rb
+++ b/spec/protobuf/nats/client_spec.rb
@@ -112,9 +112,11 @@ describe ::Protobuf::Nats::Client do
     let(:ack) { ::Protobuf::Nats::Messages::ACK }
     let(:nack) { ::Protobuf::Nats::Messages::NACK }
     let(:response) { "final count down" }
+    let(:subscription_inbox) { ::Protobuf::Nats::Client::SubscriptionInbox.new(double("sub", :is_valid => true), "INBOX") }
 
     before do
       allow(::Protobuf::Nats).to receive(:client_nats_connection).and_return(client)
+      allow_any_instance_of(::Protobuf::Nats::Client).to receive(:new_subscription_inbox).and_return(subscription_inbox)
     end
 
     it "processes a request and return the final response" do
@@ -156,6 +158,12 @@ describe ::Protobuf::Nats::Client do
   end
 
   describe "#send_request" do
+    let(:subscription_inbox) { ::Protobuf::Nats::Client::SubscriptionInbox.new(double("sub", :is_valid => true), "INBOX") }
+
+    before do
+      allow_any_instance_of(::Protobuf::Nats::Client).to receive(:new_subscription_inbox).and_return(subscription_inbox)
+    end
+
     it "retries 3 times when and raises a NATS timeout" do
       expect(subject).to receive(:setup_connection).exactly(3).times
       expect(subject).to receive(:nats_request_with_two_responses).and_return(:ack_timeout).exactly(3).times

--- a/spec/protobuf/nats/config_spec.rb
+++ b/spec/protobuf/nats/config_spec.rb
@@ -16,6 +16,8 @@ describe ::Protobuf::Nats::Config do
       :tls_client_key => nil,
       :uses_tls => false,
       :max_reconnect_attempts => 60_000,
+      :server_subscription_key_do_not_subscribe_to_when_includes_any_of => [],
+      :server_subscription_key_only_subscribe_to_when_includes_any_of => [],
       :subscription_key_replacements => [],
     }
     expect(subject.connection_options).to eq(expected_options)
@@ -57,6 +59,8 @@ describe ::Protobuf::Nats::Config do
     expect(subject.connect_timeout).to eq(2)
     expect(subject.max_reconnect_attempts).to eq(1234)
     expect(subject.subscription_key_replacements).to eq([{"original_" => "local_"}, {"another_subscription" => "different_subscription"}])
+    expect(subject.server_subscription_key_only_subscribe_to_when_includes_any_of).to eq(["search", "derp"])
+    expect(subject.server_subscription_key_do_not_subscribe_to_when_includes_any_of).to eq(["derpderp", "searchsearch"])
 
     ENV["PROTOBUF_NATS_CONFIG_PATH"] = nil
   end

--- a/spec/protobuf/nats/jnats_spec.rb
+++ b/spec/protobuf/nats/jnats_spec.rb
@@ -1,0 +1,24 @@
+require "rspec"
+
+if defined?(JRUBY_VERSION)
+  require "protobuf/nats/jnats"
+
+  describe ::Protobuf::Nats::JNats do
+    describe "#connection" do
+      it "calls #connect when no @connection exists" do
+        expect(subject).to receive(:connect).with({})
+        subject.connection
+      end
+
+      it "attempts to reconnect with options given to #connect" do
+        allow(::Java::IoNatsClient::ConnectionFactory).to receive(:new).and_raise(::RuntimeError)
+        provided_options = {:yolo => "ok"}
+        subject.connect(provided_options) rescue nil
+        expect(subject.options).to eq(provided_options)
+
+        expect(subject).to receive(:connect).with(provided_options)
+        subject.connection rescue nil
+      end
+    end
+  end
+end

--- a/spec/support/protobuf_nats.yml
+++ b/spec/support/protobuf_nats.yml
@@ -11,6 +11,12 @@
     tls_client_key: "./spec/support/certs/client-key.pem"
     tls_ca_cert: "./spec/support/certs/ca.pem"
     connect_timeout: 2
+    server_subscription_key_only_subscribe_to_when_includes_any_of:
+      - "search"
+      - "derp"
+    server_subscription_key_do_not_subscribe_to_when_includes_any_of:
+      - "derpderp"
+      - "searchsearch"
     subscription_key_replacements:
       - "original_": "local_"
       - "another_subscription": "different_subscription"


### PR DESCRIPTION
…or high req/rep throughput)

try using a pool of subscriptions and only replacing them during a timeout scenario if we configure to use subscription pooling ... also log the available size of subscriptions to instrumentation

currently only running in jruby/jnats path

@film42 @quixoten 