### PR TITLE
Abrandoned/reject select subscriptions

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,6 +76,12 @@ An example config looks like this:
     tls_client_key: "/path/to/client-key.pem"
     tls_ca_cert: "/path/to/ca.pem"
     connect_timeout: 2
+    server_subscription_key_only_subscribe_to_when_includes_any_of:
+      - "search"
+      - "create"
+    server_subscription_key_do_not_subscribe_to_when_includes_any_of:
+      - "old_search"
+      - "old_create"
     subscription_key_replacements:
       - "original_service": "replacement_service"
 ```

--- a/lib/protobuf/nats/config.rb
+++ b/lib/protobuf/nats/config.rb
@@ -4,7 +4,10 @@ require "yaml"
 module Protobuf
   module Nats
     class Config
-      attr_accessor :uses_tls, :servers, :connect_timeout, :tls_client_cert, :tls_client_key, :tls_ca_cert, :max_reconnect_attempts, :subscription_key_replacements
+      attr_accessor :uses_tls, :servers, :connect_timeout, :tls_client_cert, :tls_client_key, :tls_ca_cert, :max_reconnect_attempts
+      attr_accessor :server_subscription_key_do_not_subscribe_to_when_includes_any_of,
+                    :server_subscription_key_only_subscribe_to_when_includes_any_of,
+                    :subscription_key_replacements
 
       CONFIG_MUTEX = ::Mutex.new
 
@@ -16,6 +19,8 @@ module Protobuf
         :tls_client_key => nil,
         :tls_ca_cert => nil,
         :uses_tls => false,
+        :server_subscription_key_do_not_subscribe_to_when_includes_any_of => [],
+        :server_subscription_key_only_subscribe_to_when_includes_any_of => [],
         :subscription_key_replacements => [],
       }.freeze
 
@@ -62,6 +67,8 @@ module Protobuf
             tls_client_key: tls_client_key,
             tls_ca_cert: tls_ca_cert,
             connect_timeout: connect_timeout,
+            server_subscription_key_do_not_subscribe_to_when_includes_any_of: server_subscription_key_do_not_subscribe_to_when_includes_any_of,
+            server_subscription_key_only_subscribe_to_when_includes_any_of: server_subscription_key_only_subscribe_to_when_includes_any_of,
             subscription_key_replacements: subscription_key_replacements,
           }
           options[:tls] = {:context => new_tls_context} if uses_tls

--- a/lib/protobuf/nats/server.rb
+++ b/lib/protobuf/nats/server.rb
@@ -81,9 +81,8 @@ module Protobuf
       end
 
       def do_not_subscribe_to_includes?(subscription_key)
-        return false if ::Protobuf::Nats.config.server_subscription_key_do_not_subscribe_to_when_includes_any_of.nil?
-        return false if ::Protobuf::Nats.config.server_subscription_key_do_not_subscribe_to_when_includes_any_of.empty?
         return false unless ::Protobuf::Nats.config.server_subscription_key_do_not_subscribe_to_when_includes_any_of.respond_to?(:any?)
+        return false if ::Protobuf::Nats.config.server_subscription_key_do_not_subscribe_to_when_includes_any_of.empty?
 
         ::Protobuf::Nats.config.server_subscription_key_do_not_subscribe_to_when_includes_any_of.any? do |key|
           subscription_key.include?(key)
@@ -91,9 +90,8 @@ module Protobuf
       end
 
       def only_subscribe_to_includes?(subscription_key)
-        return true if ::Protobuf::Nats.config.server_subscription_key_only_subscribe_to_when_includes_any_of.nil?
-        return true if ::Protobuf::Nats.config.server_subscription_key_only_subscribe_to_when_includes_any_of.empty?
         return true unless ::Protobuf::Nats.config.server_subscription_key_only_subscribe_to_when_includes_any_of.respond_to?(:any?)
+        return true if ::Protobuf::Nats.config.server_subscription_key_only_subscribe_to_when_includes_any_of.empty?
 
         ::Protobuf::Nats.config.server_subscription_key_only_subscribe_to_when_includes_any_of.any? do |key|
           subscription_key.include?(key)

--- a/lib/protobuf/nats/server.rb
+++ b/lib/protobuf/nats/server.rb
@@ -86,7 +86,7 @@ module Protobuf
         return false unless ::Protobuf::Nats.config.server_subscription_key_do_not_subscribe_to_when_includes_any_of.respond_to?(:any?)
 
         ::Protobuf::Nats.config.server_subscription_key_do_not_subscribe_to_when_includes_any_of.any? do |key|
-          subscription_key.includes?(key)
+          subscription_key.include?(key)
         end
       end
 

--- a/spec/protobuf/nats/config_spec.rb
+++ b/spec/protobuf/nats/config_spec.rb
@@ -16,6 +16,8 @@ describe ::Protobuf::Nats::Config do
       :tls_client_key => nil,
       :uses_tls => false,
       :max_reconnect_attempts => 60_000,
+      :server_subscription_key_do_not_subscribe_to_when_includes_any_of => [],
+      :server_subscription_key_only_subscribe_to_when_includes_any_of => [],
       :subscription_key_replacements => [],
     }
     expect(subject.connection_options).to eq(expected_options)
@@ -57,6 +59,8 @@ describe ::Protobuf::Nats::Config do
     expect(subject.connect_timeout).to eq(2)
     expect(subject.max_reconnect_attempts).to eq(1234)
     expect(subject.subscription_key_replacements).to eq([{"original_" => "local_"}, {"another_subscription" => "different_subscription"}])
+    expect(subject.server_subscription_key_only_subscribe_to_when_includes_any_of).to eq(["search", "derp"])
+    expect(subject.server_subscription_key_do_not_subscribe_to_when_includes_any_of).to eq(["derpderp", "searchsearch"])
 
     ENV["PROTOBUF_NATS_CONFIG_PATH"] = nil
   end

--- a/spec/support/protobuf_nats.yml
+++ b/spec/support/protobuf_nats.yml
@@ -11,6 +11,12 @@
     tls_client_key: "./spec/support/certs/client-key.pem"
     tls_ca_cert: "./spec/support/certs/ca.pem"
     connect_timeout: 2
+    server_subscription_key_only_subscribe_to_when_includes_any_of:
+      - "search"
+      - "derp"
+    server_subscription_key_do_not_subscribe_to_when_includes_any_of:
+      - "derpderp"
+      - "searchsearch"
     subscription_key_replacements:
       - "original_": "local_"
       - "another_subscription": "different_subscription"


### PR DESCRIPTION
allow for `only` and `do not` for inclusion keys in configuration file (clearly can expand for future use around "include all of" vs any) but I think this will serve our purposes for now (but naming may be a bit verbose, but I always error on that side)

@quixoten @film42 