### PR TITLE
We're no longer using start_client_nats_connection

### DIFF
--- a/lib/protobuf/nats.rb
+++ b/lib/protobuf/nats.rb
@@ -78,11 +78,10 @@ module Protobuf
     end
 
     def self.start_client_nats_connection
-      return true if @start_client_nats_connection && @client_nats_connection
+      return true if @client_nats_connection
 
       GET_CONNECTED_MUTEX.synchronize do
         break true if @client_nats_connection
-        break true if @start_client_nats_connection
 
         # Disable publisher pending buffer on reconnect
         options = config.connection_options.merge(:disable_reconnect_buffer => true)


### PR DESCRIPTION
We used this to `||=` memo before but we no longer need it. Better to check the actual connection instance.

cc @liveh2o @abrandoned @quixoten 