### PR TITLE
Lock down nats-pure

### DIFF
--- a/protobuf-nats.gemspec
+++ b/protobuf-nats.gemspec
@@ -33,7 +33,7 @@ Gem::Specification.new do |spec|
   spec.add_runtime_dependency "activesupport", ">= 3.2"
   spec.add_runtime_dependency "connection_pool"
   spec.add_runtime_dependency "protobuf", "~> 3.7", ">= 3.7.2"
-  spec.add_runtime_dependency "nats-pure"
+  spec.add_runtime_dependency "nats-pure", "~> 0.3", "< 0.4"
 
   spec.add_development_dependency "bundler", "~> 1.14"
   spec.add_development_dependency "rake", "~> 10.0"


### PR DESCRIPTION
There was a recent change that switched the subscription path to create a new thread each time. This change started causing resource conception errors leading to processes halting. We should implement either a single request subscription and handle the dispatch like go and other community libs, or we implement the subscription pool for mri, which has its own challenges. This PR comes after a first cut at making our existing code work.

cc @quixoten @liveh2o @abrandoned 