### PR TITLE
converts timers to milliseconds as statsd timers explicitly say to re…

### DIFF
--- a/lib/protobuf/nats/server.rb
+++ b/lib/protobuf/nats/server.rb
@@ -12,6 +12,8 @@ module Protobuf
 
       attr_reader :nats, :thread_pool, :subscriptions
 
+      MILLISECOND = 1000
+
       def initialize(options)
         @options = options
         @processing_requests = true
@@ -52,7 +54,7 @@ module Protobuf
             # Instrument the thread pool time-to-execute duration.
             processed_at = ::Time.now
             ::ActiveSupport::Notifications.instrument("server.thread_pool_execution_delay.protobuf-nats",
-                                                      (processed_at - enqueued_at))
+                                                      (processed_at - enqueued_at) * MILLISECOND)
 
             # Process request.
             response_data = handle_request(request_data, 'server' => @server)
@@ -64,7 +66,7 @@ module Protobuf
             # Instrument the request duration.
             completed_at = ::Time.now
             ::ActiveSupport::Notifications.instrument("server.request_duration.protobuf-nats",
-                                                      (completed_at - enqueued_at))
+                                                      (completed_at - enqueued_at) * MILLISECOND)
           end
         end
 


### PR DESCRIPTION
Statsd docs specify timers should be reported in milliseconds.  This converts the time reportings to milliseconds for finer granularity.