### PR TITLE
Include service and method name with Request/Response timeout errors

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,7 @@
 sudo: false
 language: ruby
+jdk:
+ - openjdk8
 rvm:
   - 2.3.0
   - jruby-9.1.7.0

--- a/lib/protobuf/nats/errors.rb
+++ b/lib/protobuf/nats/errors.rb
@@ -1,13 +1,13 @@
 module Protobuf
   module Nats
     module Errors
-      class Base < ::StandardError
+      class ClientError < ::StandardError
       end
 
-      class RequestTimeout < Base
+      class RequestTimeout < ClientError
       end
 
-      class ResponseTimeout < Base
+      class ResponseTimeout < ClientError
       end
 
       class MriIOException < ::StandardError

--- a/protobuf-nats.gemspec
+++ b/protobuf-nats.gemspec
@@ -35,7 +35,7 @@ Gem::Specification.new do |spec|
   spec.add_runtime_dependency "protobuf", "~> 3.7", ">= 3.7.2"
   spec.add_runtime_dependency "nats-pure", "~> 0.3", "< 0.4"
 
-  spec.add_development_dependency "bundler", "~> 1.14"
+  spec.add_development_dependency "bundler"
   spec.add_development_dependency "rake", "~> 10.0"
   spec.add_development_dependency "rspec"
   spec.add_development_dependency "benchmark-ips"

--- a/spec/protobuf/nats/client_spec.rb
+++ b/spec/protobuf/nats/client_spec.rb
@@ -146,7 +146,7 @@ describe ::Protobuf::Nats::Client do
       client.schedule_messages([::FakeNatsClient::Message.new(inbox, ack, 0.05)])
 
       options = {:timeout => 0.1}
-      expect { subject.nats_request_with_two_responses(msg_subject, "request data", options) }.to raise_error(::Protobuf::Nats::Errors::ResponseTimeout)
+      expect { subject.nats_request_with_two_responses(msg_subject, "request data", options) }.to raise_error(::Protobuf::Nats::Errors::ResponseTimeout, "ExampleServiceClass#created")
     end
 
     it "returns :nack when the server responds with nack" do
@@ -167,7 +167,7 @@ describe ::Protobuf::Nats::Client do
     it "retries 3 times when and raises a NATS timeout" do
       expect(subject).to receive(:setup_connection).exactly(3).times
       expect(subject).to receive(:nats_request_with_two_responses).and_return(:ack_timeout).exactly(3).times
-      expect { subject.send_request }.to raise_error(::Protobuf::Nats::Errors::RequestTimeout)
+      expect { subject.send_request }.to raise_error(::Protobuf::Nats::Errors::RequestTimeout, "ExampleServiceClass#created")
     end
 
     it "retries when the server responds with NACK" do
@@ -179,7 +179,7 @@ describe ::Protobuf::Nats::Client do
       expect(subject).to receive(:sleep).with(30*0.001).ordered
       expect(subject).to receive(:setup_connection).exactly(3).times
       expect(subject).to receive(:nats_request_with_two_responses).exactly(3).times.and_call_original
-      expect { subject.send_request }.to raise_error(::Protobuf::Nats::Errors::RequestTimeout)
+      expect { subject.send_request }.to raise_error(::Protobuf::Nats::Errors::RequestTimeout, "ExampleServiceClass#created")
     end
 
     it "waits the reconnect_delay duration when the nats connection is reconnecting" do


### PR DESCRIPTION
This should make any request/response timeouts much easier to understand. Previously the service/method were not included in the error. Now we'll add a `Service#method` in each request or response timeout error. See tests for examples.

cc @liveh2o @abrandoned 