### PR TITLE
check for unsafe_load_file and use it if present

### DIFF
--- a/lib/protobuf/nats/config.rb
+++ b/lib/protobuf/nats/config.rb
@@ -40,7 +40,12 @@ module Protobuf
             config_path = ENV["PROTOBUF_NATS_CONFIG_PATH"] || ::File.join("config", "protobuf_nats.yml")
             absolute_config_path = ::File.expand_path(config_path)
             if ::File.exists?(absolute_config_path)
-              yaml_config = ::YAML.load_file(absolute_config_path)[env]
+              # Psych 4 and newer requires unsafe_load_file in order for aliases to be used
+              yaml_config = if ::YAML.respond_to?(:unsafe_load_file)
+                ::YAML.unsafe_load_file(absolute_config_path)[env]
+              else
+                ::YAML.load_file(absolute_config_path)[env]
+              end
             end
 
             DEFAULTS.each_pair do |key, value|


### PR DESCRIPTION
When using aliases in Psych 4 and newer we need to call unsafe_load_file for them to be processed correctly.